### PR TITLE
Add HTTP 503 status code to response

### DIFF
--- a/MaintenanceWorker.js
+++ b/MaintenanceWorker.js
@@ -15,6 +15,7 @@ async function fetchAndReplace(request) {
   {
     // Return modified response.
     return new Response(maintPage, {
+      status: 503,
       headers: modifiedHeaders
     })
   }


### PR DESCRIPTION
An HTTP 503 status will tell browsers (and search engines) that your site is temporarily unavailable. Otherwise, Cloudflare Workers return a 200 status, indicating the server is working normally and the maintenance page is its regular content.